### PR TITLE
fix(useInterval): use a memoized function

### DIFF
--- a/src/useInterval.js
+++ b/src/useInterval.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 
 /**
  * Wraps `setInterval`. Triggers the function each interval.
@@ -7,8 +7,9 @@ import { useEffect } from 'react'
  * @return {void}
  */
 export default function useInterval(fn, interval) {
+  const memoizedFn = useCallback(fn)
   useEffect(() => {
-    const id = setInterval(fn, interval)
+    const id = setInterval(memoizedFn, interval)
     return () => clearInterval(id)
-  })
+  }, [])
 }


### PR DESCRIPTION
By memoizing the function via `useCallback` within `useInterval`, coupled with the explicit cache of `[]` (meaning that the effect only has an onMount and onUnmount), only a single interval is kept for the lifecycle of the component, that will be appropriately called with updated props/state.