### PR TITLE
fix(useUnmount): use a memoized function

### DIFF
--- a/src/useUnmount.js
+++ b/src/useUnmount.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 
 /**
  * Triggers the function when the component is unmounted. You can pass options
@@ -10,5 +10,6 @@ import { useEffect } from 'react'
  * @return {void}
  */
 export default function useUnmount(fn, { hook = useEffect } = {}) {
-  hook(() => fn, [])
+  const memoizedFn = useCallback(fn)
+  hook(() => memoizedFn, [])
 }


### PR DESCRIPTION
Because of the use of the `[]` cache, only the first function that was passed in would have been used during the unmount process. This ensures that the most recent render's `fn` will be used on the final unmount.

The same consideration does not need to be taken for `useMount`.